### PR TITLE
fixed used of N/A to prevent errors and removed kosher from restrictions

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,9 +13,9 @@ import bcrypt
 
 origins = [
     "http://54-165-70-250:3000",
-    "http://ec2-54-165-70-250.compute-1.amazonaws.com:3000",
+    "http://localhost:3000",
     "54-165-70-250:3000",
-    "ec2-54-165-70-250.compute-1.amazonaws.com:3000"
+    "localhost:3000"
 ]
 
 user_middlewares = []
@@ -117,7 +117,7 @@ async def submit_questionnaire(request: Request):
     updatePositives(id, positives_list)
     updateNegatives(id, negatives_list)
     # checks if the N/A option is selected
-    if len(restrictions) != 1 or restrictions[0] != 'N/A':
+    if "N/A" not in restrictions:
         updateRestrictions(id, restrictions_list)
     return {"message": "submitted"}
 

--- a/backend/data_generation/data_gen_constants.py
+++ b/backend/data_generation/data_gen_constants.py
@@ -127,7 +127,6 @@ restrictions_dict = {
     'Vegan': 'vegan',
     'Vegetarian': 'vegetarian',
     'Gluten Free': 'gluten_free',
-    'Kosher': 'kosher',
     'N/A': 'none'
 }
 

--- a/backend/db/db_management.py
+++ b/backend/db/db_management.py
@@ -43,7 +43,7 @@ mydb = mysql.connector.connect(**config)
 #         mydb.close()
 #         print("MySQL Connection is closed")
 
-# mydb = mysql.connector.connect(host='ec2-54-165-70-250.compute-1.amazonaws.com',
+# mydb = mysql.connector.connect(host='localhost',
 #                                         database='Users',
 #                                         user='root',
 #                                         password='Password')
@@ -173,7 +173,10 @@ def retrieveRestrictions(id):
 
     result = c.fetchone()
     # returns the list of restrictions for a given user's ID
-    return result[0].split(',')
+    restrictions = result[0].split(',')
+    if len(restrictions) == 1 and restrictions[0] == '':
+        return []
+    return restrictions
 
 def getNameByID(id):
     c = mydb.cursor()

--- a/restaurant_suggester.py
+++ b/restaurant_suggester.py
@@ -60,7 +60,7 @@ def build_user_features(occasion, num_people, meal, price_ranges, positives, neg
         'covid': 0
     }
     # iterates through the restrictions the user chose and assigns a value of 1 to it
-    print(restrictions)
+    print("restrictions: " + str(restrictions))
     for restriction in restrictions:
         if restriction == '':
             continue
@@ -196,6 +196,8 @@ def get_predictions(id, occasion, num_people, meal, price_ranges, zip):
     positives = user_info[0].split(',')
     negatives = user_info[1].split(',')
     restrictions = user_info[2].split(',')
+    if len(restrictions) == 1 and restrictions[0] == '':
+        restrictions = []
     
     # gets the user input for profile information (used for testing)
     user_features = build_user_features(occasion, num_people, meal, price_ranges, positives, negatives, restrictions)


### PR DESCRIPTION
- Selecting 'N/A' as an option no longer adds anything to the DB
- There was a bug when a user had nothing in the DB for restrictions with db_management.py code returning [''] instead of []. This is now fixed
- The 'Kosher' option has been removed from the restrictions list